### PR TITLE
Fix compilation for Linux >= 5.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.cmd
+*.ko
+*.mod
+*.mod.c
+*.o
+*.order
+*.symvers
+

--- a/can-ibxxx_socketcan/ixx_pci_core.c
+++ b/can-ibxxx_socketcan/ixx_pci_core.c
@@ -235,24 +235,25 @@ void ixxat_dump_mem(char *prompt, void *p, int l)
         DUMP_WIDTH, 1, p, l, false);
 }
 
-static void ixxat_pci_add_us(struct timeval *tv, u64 delta_us)
+static void ixxat_pci_add_us(struct timespec64 *tv, u64 delta_us)
 {
         /* number of s. to add to final time */
         u32 delta_s = div_u64(delta_us, 1000000);
 
         delta_us -= delta_s * 1000000;
 
-        tv->tv_usec += delta_us;
-        if (tv->tv_usec >= 1000000) {
-                tv->tv_usec -= 1000000;
+        tv->tv_nsec += delta_us * 1000;
+        if (tv->tv_nsec >= 1000000000) {
+                tv->tv_nsec -= 1000000000;
                 delta_s++;
         }
+
         tv->tv_sec += delta_s;
 }
 
 void ixxat_pci_get_ts_tv(struct ixx_pci_priv *dev, u32 ts, ktime_t *k_time)
 {
-        struct timeval tv = dev->time_ref.tv_host_0;
+        struct timespec64 tv = dev->time_ref.tv_host_0;
 
         if (ts < dev->time_ref.ts_dev_last) {
                 ixxat_pci_update_ts_now(dev, ts);
@@ -261,7 +262,7 @@ void ixxat_pci_get_ts_tv(struct ixx_pci_priv *dev, u32 ts, ktime_t *k_time)
         dev->time_ref.ts_dev_last = ts;
         ixxat_pci_add_us(&tv, ts - dev->time_ref.ts_dev_0);
 
-        *k_time = timeval_to_ktime(tv);
+        *k_time = timespec64_to_ktime(tv);
 }
 
 void ixxat_pci_update_ts_now(struct ixx_pci_priv *dev, u32 hw_time_base)
@@ -278,12 +279,8 @@ void ixxat_pci_update_ts_now(struct ixx_pci_priv *dev, u32 hw_time_base)
 void ixxat_pci_set_ts_now(struct ixx_pci_priv *dev, u32 hw_time_base)
 {
         dev->time_ref.ts_dev_0 = hw_time_base;
-        
-        #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
-        do_gettimeofday(&dev->time_ref.tv_host_0);
-        #else
+
         ktime_get_real_ts64((struct timespec64*)&dev->time_ref.tv_host_0);
-        #endif
 
         dev->time_ref.ts_dev_last = hw_time_base;
 }

--- a/can-ibxxx_socketcan/ixx_pci_core.h
+++ b/can-ibxxx_socketcan/ixx_pci_core.h
@@ -241,7 +241,7 @@ struct ixx_canfd_msg {
 } __packed;
 
 struct ixx_time_ref {
-        struct timeval tv_host_0;
+        struct timespec64 tv_host_0;
         u32 ts_dev_0;
         u32 ts_dev_last;
 };

--- a/can-ibxxx_socketcan/ixx_pci_ib_active.c
+++ b/can-ibxxx_socketcan/ixx_pci_ib_active.c
@@ -210,7 +210,7 @@ MODULE_SUPPORTED_DEVICE("IXXAT Automation GmbH CAN-IB2x0, CAN-IB4x0, CAN-IB6x0 a
 #define CAN_IB2X0_BMG_WRITE_BLOCK_CMD \
                 CAN_IB2X0_BMG_CMD_CODE(CAN_IB2X0_BMG_CMD_CAT, 4)
 
-#define CAN_IB2X0_CMD_TIMEOUT_US    500000
+#define CAN_IB2X0_CMD_TIMEOUT_NS    500000000
 
 /* request packet header  */
 struct ixx_dal_req {
@@ -369,7 +369,7 @@ static int ixx_act_ib_xxx_rcv_cmd(struct ixx_pci_interface *intf, u32 *rx_fifo,
         u32* res_size;
         struct ixx_dal_req *res_dal_req;
         u32 read_index, write_index, data_offset;
-        struct timeval start, end;
+        struct timespec64 start, end;
         size_t dal_size = sizeof(struct ixx_dal_req);
 
         write_index = rx_fifo[CAN_IB2X0_PCR_RES_WRITE_IDX];
@@ -378,15 +378,11 @@ static int ixx_act_ib_xxx_rcv_cmd(struct ixx_pci_interface *intf, u32 *rx_fifo,
         if (rx_fifo[CAN_IB2X0_PCR_RES_DIR] != CAN_IB2X0_PCR_RESDIR_DTOH)
                 return -EBADSLT;
 
-        #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
-        do_gettimeofday(&start);
-        #else
         ktime_get_real_ts64((struct timespec64*)&start);
-        #endif
 
         end = start;
 
-        while ((end.tv_usec - start.tv_usec) < CAN_IB2X0_CMD_TIMEOUT_US) {
+        while ((end.tv_nsec - start.tv_nsec) < CAN_IB2X0_CMD_TIMEOUT_NS) {
                 if (++read_index == rx_fifo[CAN_IB2X0_PCR_RES_NUM_OBJ])
                         read_index = 0;
 
@@ -442,11 +438,7 @@ static int ixx_act_ib_xxx_rcv_cmd(struct ixx_pci_interface *intf, u32 *rx_fifo,
 
                 return dal_res->ret_code;
 
-                #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
-                cmd_continue: do_gettimeofday(&end);
-                #else
-                cmd_continue: ktime_get_real_ts64((struct timespec64*)&end);
-                #endif
+                cmd_continue: ktime_get_real_ts64(&end);
         }
 
         return err;

--- a/can-ibxxx_socketcan/ixx_pci_ib_active.c
+++ b/can-ibxxx_socketcan/ixx_pci_ib_active.c
@@ -1862,17 +1862,17 @@ static int ixx_act_ib_xxx_probe(struct pci_dev *pdev,
         intf->memlen = pci_resource_len(pdev, 2);
 
         request_mem_region(intf->reg1add, intf->reg1len, "IXXAT PCI Registers");
-        intf->reg1vadd = ioremap_nocache(intf->reg1add, intf->reg1len);
+        intf->reg1vadd = ioremap(intf->reg1add, intf->reg1len);
         if (!intf->reg1vadd) {
-                printk("reg1vadd ioremap_nocache failed\n");
+                printk("reg1vadd ioremap failed\n");
                 err = -ENOBUFS;
                 goto release_reg1;
         }
 
         request_mem_region(intf->memadd, intf->memlen, "IXXAT PCI Memory");
-        intf->memvadd = ioremap_nocache(intf->memadd, intf->memlen);
+        intf->memvadd = ioremap(intf->memadd, intf->memlen);
         if (!intf->memvadd) {
-                printk("memvadd ioremap_nocache failed\n");
+                printk("memvadd ioremap failed\n");
                 err = -ENOBUFS;
                 goto release_memreg;
         }

--- a/can-ibxxx_socketcan/ixx_pci_ib_fd_passive.c
+++ b/can-ibxxx_socketcan/ixx_pci_ib_fd_passive.c
@@ -1193,17 +1193,17 @@ static int ixx_pas_ib_fd_xxx_probe(struct pci_dev *pdev,
         intf->memlen = pci_resource_len(pdev, 2);
 
         request_mem_region(intf->memadd, intf->memlen, "IXXAT PCI Memory");
-        intf->memvadd = ioremap_nocache(intf->memadd, intf->memlen);
+        intf->memvadd = ioremap(intf->memadd, intf->memlen);
         if (!intf->memvadd) {
-                printk("memvadd ioremap_nocache failed\n");
+                printk("memvadd ioremap failed\n");
                 err = -ENOBUFS;
                 goto release_memreg;
         }
 
         request_mem_region(intf->reg1add, intf->reg1len, "IXXAT PCI Registers");
-        intf->reg1vadd = ioremap_nocache(intf->reg1add, intf->reg1len);
+        intf->reg1vadd = ioremap(intf->reg1add, intf->reg1len);
         if (!intf->reg1vadd) {
-                printk("reg1vadd ioremap_nocache failed\n");
+                printk("reg1vadd ioremap failed\n");
                 err = -ENOBUFS;
                 goto release_reg1;
         }

--- a/can-ibxxx_socketcan/ixx_pci_ib_passive.c
+++ b/can-ibxxx_socketcan/ixx_pci_ib_passive.c
@@ -1221,17 +1221,17 @@ static int ixx_pas_ib_xxx_probe(struct pci_dev *pdev,
         intf->memlen = pci_resource_len(pdev, 2);
 
         request_mem_region(intf->memadd, intf->memlen, "IXXAT PCI Memory");
-        intf->memvadd = ioremap_nocache(intf->memadd, intf->memlen);
+        intf->memvadd = ioremap(intf->memadd, intf->memlen);
         if (!intf->memvadd) {
-                printk("memvadd ioremap_nocache failed\n");
+                printk("memvadd ioremap failed\n");
                 err = -ENOBUFS;
                 goto release_memreg;
         }
 
         request_mem_region(intf->reg1add, intf->reg1len, "IXXAT PCI Registers");
-        intf->reg1vadd = ioremap_nocache(intf->reg1add, intf->reg1len);
+        intf->reg1vadd = ioremap(intf->reg1add, intf->reg1len);
         if (!intf->reg1vadd) {
-                printk("reg1vadd ioremap_nocache failed\n");
+                printk("reg1vadd ioremap failed\n");
                 err = -ENOBUFS;
                 goto release_reg1;
         }

--- a/usb-to-can_socketcan/ixx_usb_core.h
+++ b/usb-to-can_socketcan/ixx_usb_core.h
@@ -193,7 +193,7 @@ struct ixx_usb_adapter {
 };
 
 struct ixx_time_ref {
-        struct timeval tv_host_0;
+        struct timespec64 tv_host_0;
         u32 ts_dev_0;
         u32 ts_dev_last;
 };


### PR DESCRIPTION
Fixes #2 

Tested on 
- Ubuntu 20.04.2 LTS with 5.8 Kernel 
- IXXAT USB-to-CAN FD Compact