### PR TITLE
Fixes for kernel 5.11.0

### DIFF
--- a/can-ibxxx_socketcan/ixx_pci_ib_active.c
+++ b/can-ibxxx_socketcan/ixx_pci_ib_active.c
@@ -32,7 +32,6 @@
 #include <linux/firmware.h>
 #include <linux/time.h>
 
-#include <asm-generic/kmap_types.h>
 #include <asm-generic/errno.h>
 
 #include <stdarg.h>
@@ -875,7 +874,7 @@ static int ixx_act_ib_xxx_handle_srr_canfdmsg(struct ixx_pci_priv *priv,
         ifi_reg_dlc = le32_to_cpu(ifi_base[IXX_IFI_DLC]);
 
         priv->netdev->stats.tx_packets += 1;
-        priv->netdev->stats.tx_bytes += can_dlc2len(
+        priv->netdev->stats.tx_bytes += can_fd_dlc2len(
                         ifi_reg_dlc & IFIFD_RXFIFO_DLC);
         frn = (ifi_reg_dlc & IFIFD_RXFIFO_FRN) >> IFIFD_RXFIFO_FRN_S;
 
@@ -952,7 +951,7 @@ static int ixx_act_ib_xxx_handle_canfdmsg(struct ixx_pci_priv *priv,
         raw_dlc = le32_to_cpu(ifi_base[IXX_IFI_DLC]);
         raw_id = le32_to_cpu(ifi_base[IXX_IFI_ID]);
 
-        can_frame->len = can_dlc2len(
+        can_frame->len = can_fd_dlc2len(
                         (raw_dlc & IFIFD_RXFIFO_DLC) >> IFIFD_RXFIFO_DLC_S);
 
         if (raw_id & IFIFD_RXFIFO_IDE) {
@@ -1569,7 +1568,7 @@ static int ixx_act_ib_xxx_start_xmit_fd(struct sk_buff *skb,
         if (cf->can_id & CAN_RTR_FLAG)
                 can_dlc |= IFIFD_TXFIFO_RTR;
         else {
-                can_dlc |= can_len2dlc(cf->len) & IFIFD_TXFIFO_DLC;
+                can_dlc |= can_fd_len2dlc(cf->len) & IFIFD_TXFIFO_DLC;
                 if (cf->len > 8) {
                         can_dlc |= IFIFD_TXFIFO_EDL;
                 }

--- a/can-ibxxx_socketcan/ixx_pci_ib_fd_passive.c
+++ b/can-ibxxx_socketcan/ixx_pci_ib_fd_passive.c
@@ -209,7 +209,7 @@ static int ixx_pas_ib_fd_xxx_handle_srr_canmsg(struct ixx_pci_priv *priv)
                         ioread32(priv->ifi_base + IFIFDREG_RX_FIFO_DLC));
 
         priv->netdev->stats.tx_packets += 1;
-        priv->netdev->stats.tx_bytes += can_dlc2len(
+        priv->netdev->stats.tx_bytes += can_fd_dlc2len(
                         ifi_reg_dlc & IFIFD_RXFIFO_DLC);
         frn = (ifi_reg_dlc & IFIFD_RXFIFO_FRN) >> IFIFD_RXFIFO_FRN_S;
 
@@ -237,7 +237,7 @@ static int ixx_pas_ib_fd_xxx_handle_canmsg(struct ixx_pci_priv *priv)
         raw_id = le32_to_cpu(ioread32(priv->ifi_base + IFIFDREG_RX_FIFO_ID));
         raw_dlc = le32_to_cpu(ioread32(priv->ifi_base + IFIFDREG_RX_FIFO_DLC));
 
-        can_frame->len = can_dlc2len(
+        can_frame->len = can_fd_dlc2len(
                         le32_to_cpu(
                                         (raw_dlc & IFIFD_RXFIFO_DLC)
                                                         >> IFIFD_RXFIFO_DLC_S));
@@ -500,7 +500,7 @@ static int ixx_pas_ib_fd_xxx_start_xmit(struct sk_buff *skb,
         if (cf->can_id & CAN_RTR_FLAG)
                 can_dlc |= IFIFD_TXFIFO_RTR;
 
-        can_dlc |= can_len2dlc(cf->len) & IFIFD_TXFIFO_DLC;
+        can_dlc |= can_fd_len2dlc(cf->len) & IFIFD_TXFIFO_DLC;
 
         if (skb->len == CANFD_MTU) {
                 can_dlc |= IFIFD_TXFIFO_EDL;

--- a/usb-to-can_socketcan/ixx_usb_fd.c
+++ b/usb-to-can_socketcan/ixx_usb_fd.c
@@ -614,22 +614,8 @@ static int ixx_usbfd_handle_canmsg(struct ixx_usb_device *dev,
 	if (!skb)
 		return -ENOMEM;
 
-	if (flags & IXXAT_USBFD_MSG_FLAGS_EDL) {
-		if (flags & IXXAT_USBFD_MSG_FLAGS_FDR)
-			can_frame->flags |= CANFD_BRS;
-
-		if (flags & IXXAT_USBFD_MSG_FLAGS_ESI)
-			can_frame->flags |= CANFD_ESI;
-
-		can_frame->len =
-			can_dlc2len(
-			get_canfd_dlc((flags & IXXAT_USBFD_MSG_FLAGS_DLC)
-			>> 16));
-	}	else {
-		can_frame->len =
-			get_canfd_dlc((flags & IXXAT_USBFD_MSG_FLAGS_DLC)
-			>> 16);
-	}
+    can_frame->len =
+		can_fd_dlc2len((flags & IXXAT_USBFD_MSG_FLAGS_DLC) >> 16);
 
 	if (flags & IXXAT_USBFD_MSG_FLAGS_OVR) {
 		netdev->stats.rx_over_errors++;
@@ -896,7 +882,7 @@ static int ixx_usbfd_encode_msg(struct ixx_usb_device *dev, struct sk_buff *skb,
 			can_msg.flags |= IXXAT_USBFD_MSG_FLAGS_FDR;
 	}
 
-	can_msg.flags |= (can_len2dlc(cf->len) << 16) &
+	can_msg.flags |= (can_fd_len2dlc(cf->len) << 16) &
 		IXXAT_USBFD_MSG_FLAGS_DLC;
 
 	can_msg.flags = cpu_to_le32(can_msg.flags);

--- a/usb-to-can_socketcan/ixx_usb_fd.c
+++ b/usb-to-can_socketcan/ixx_usb_fd.c
@@ -614,8 +614,22 @@ static int ixx_usbfd_handle_canmsg(struct ixx_usb_device *dev,
 	if (!skb)
 		return -ENOMEM;
 
-    can_frame->len =
-		can_fd_dlc2len((flags & IXXAT_USBFD_MSG_FLAGS_DLC) >> 16);
+
+    	if (flags & IXXAT_USBFD_MSG_FLAGS_EDL) {
+		if (flags & IXXAT_USBFD_MSG_FLAGS_FDR)
+			can_frame->flags |= CANFD_BRS;
+
+		if (flags & IXXAT_USBFD_MSG_FLAGS_ESI)
+			can_frame->flags |= CANFD_ESI;
+
+		can_frame->len =
+			can_fd_dlc2len((flags & IXXAT_USBFD_MSG_FLAGS_DLC)
+			>> 16);
+	}	else {
+		can_frame->len =
+			can_fd_dlc2len((flags & IXXAT_USBFD_MSG_FLAGS_DLC)
+			>> 16);
+	}
 
 	if (flags & IXXAT_USBFD_MSG_FLAGS_OVR) {
 		netdev->stats.rx_over_errors++;


### PR DESCRIPTION
Rename can_dlc2len to can_fd_dlc2len
Rename can_len2dlc to can_fd_len2dlc
Remove get_canfd_dlc